### PR TITLE
Generate API document using GitHub Actions

### DIFF
--- a/.github/workflows/todo-app.yml
+++ b/.github/workflows/todo-app.yml
@@ -1,0 +1,28 @@
+name: Generate document for todo-app
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Generate Swagger UI
+        uses: Legion2/swagger-ui-action@v1
+        with:
+          output: public/todo-app
+          spec-file: ./todo-app/openapi.json
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: public
+          keep_files: true


### PR DESCRIPTION
Add `.github/workflows/todo-app.yml` file to build and deploy API document for todo-app.