### PR TITLE
Fix failure to generate documentation with GitHub Actions

### DIFF
--- a/.github/workflows/todo-app.yml
+++ b/.github/workflows/todo-app.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/todo-app.yml
+++ b/.github/workflows/todo-app.yml
@@ -18,7 +18,7 @@ jobs:
         uses: Legion2/swagger-ui-action@v1
         with:
           output: public/todo-app
-          spec-file: ./todo-app/openapi.json
+          spec-file: ./todo-app/openapi.yaml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/todo-app.yml
+++ b/.github/workflows/todo-app.yml
@@ -21,10 +21,10 @@ jobs:
         with:
           output: public/todo-app
           spec-file: ./todo-app/openapi.yaml
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          personal_token: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: public
           keep_files: true

--- a/.github/workflows/todo-app.yml
+++ b/.github/workflows/todo-app.yml
@@ -21,10 +21,10 @@ jobs:
         with:
           output: public/todo-app
           spec-file: ./todo-app/openapi.yaml
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_DEPLOY_KEY }}
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: public
           keep_files: true

--- a/.github/workflows/todo-app.yml
+++ b/.github/workflows/todo-app.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,6 +26,6 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          personal_token: ${{ secrets.DEPLOY_PERSONAL_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: public
           keep_files: true

--- a/.github/workflows/todo-app.yml
+++ b/.github/workflows/todo-app.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          personal_token: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          personal_token: ${{ secrets.DEPLOY_PERSONAL_TOKEN }}
           publish_dir: public
           keep_files: true


### PR DESCRIPTION
Fix OpenAPI specification file extension: change from `JSON` to `YAML`.

Add write permission for the GitHub repository.

Build and deploy job will only run on the `main` branch.