### PR TITLE
To-do API specification 설계하기

### DIFF
--- a/todo-app/openapi.yaml
+++ b/todo-app/openapi.yaml
@@ -19,7 +19,7 @@ paths:
         API 서버가 잘 작동하는지 확인하는 용도의 API.
       responses:
         '200':
-          description: 멀쩡함.
+          description: 서버가 정상 작동함
   /tasks:
     get:
       tags:
@@ -52,3 +52,118 @@ paths:
                           type: string
                           description: 할 일 등록 일시 (UTC)
                           example: "2024-10-01 12:34:56"
+        post:
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    contents:
+                      type: string
+                      description: 내용
+                      example: "오늘 할 일"
+          responses:
+            200:
+              description: Task 저장 결과
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      id:
+                        type: number
+                        description: 저장 된 id 값
+                        example: 1
+                      contents:
+                        type: string
+                        description: 내용
+                        example: "오늘 할 일"
+            400:
+              description: 잘못된 입력 형식
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      error:
+                        type: string
+                        example: "문자열 타입이 아닙니다."
+    /tasks/{taskId}:
+      get:
+        parameters:
+          - name: taskId
+            in: path
+            required: true
+            schema:
+              type: string
+        responses:
+          200:
+            description: Task 목록 조회
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Task'
+      patch:
+        parameters:
+          - name: taskId
+            in: path
+            required: true
+            schema:
+              type: string
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contents:
+                    type: string
+                    description: 내용
+                    example: "내일 할 일"
+        responses:
+          200:
+            description: Task 수정 결과
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    id:
+                      type: number
+                      description: 저장 된 id 값
+                      example: 1
+                    contents:
+                      type: string
+                      description: 내용
+                      example: "내일 할 일"
+      delete:
+        parameters:
+          - name: taskId
+            in: path
+            required: true
+            schema:
+              type: string
+        responses:
+          200:
+            description: Task 삭제 결과
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    message:
+                      type: string
+                      description: 삭제 성공
+                      example: "success"
+components:
+  schemas:
+    Task:
+      type: object
+      properties:
+        id:
+          type: integer
+        content:
+          type: string


### PR DESCRIPTION
## 개선 사항
### 1. 할 일 (`Task`) 관리 API 구현
- 할 일(`Task`)의 목록 조회, 등록, 수정, 삭제 기능을 작성했으며, 엔드포인트는 다음과 같습니다.
  - `GET /tasks`: 모든 할 일(Task) 목록을 조회
  - `POST /tasks`: 할 일을 등록
  - `GET /tasks/{taskId}`: 특정 Task ID로 할 일 조회
  - `PATCH /tasks/{taskId}`: 할 일 내용 수정
  - `DELETE /tasks/{taskId}`: 할 일 삭제
### 2. 상태 확인 API 추가
- 서버 상태를 확인할 수 있는 엔드포인트 `/`를 추가했습니다. 서버가 정상 작동하는지 확인하는 용도로 사용되며, 정상일 경우 200 응답을 반환합니다.
### 3. 입출력에 대한 유효성 검사
- 잘못된 입력 데이터에 대한 400 응답이 반환합니다. 예를들어 `POST /tasks`에 `contents`에 문자열 외 타입에 대해 400 에러 메세지를 반환합니다.
## 개선 이유
- 기능 확장 추가
   - Task 기본적인 CRUD 관리 API를 통해 기능 확장 및 유지보수가 용하도록 설계했습니다.
- 클라이언트 개발
   - 클라이언트 개발자들이 일관된 형식의 데이터를 받을 수 있으며, 유효성 검사를 통해 올바른 데이터 타입을 처리하도록 했습니다.