### PR TITLE
Tickets API Swagger UI도 웹으로 발행

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,4 +1,4 @@
-name: Generate document for todo-app
+name: Build and Deploy
 
 on:
   push:
@@ -17,11 +17,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Generate Swagger UI
+      - name: Generate Swagger UI for Todo App
         uses: Legion2/swagger-ui-action@v1
         with:
           output: public/todo-app
           spec-file: ./todo-app/openapi.yaml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate Swagger UI for Tickets API
+        uses: Legion2/swagger-ui-action@v1
+        with:
+          output: public/tickets
+          spec-file: ./tickets/openapi.yaml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/tickets/README.md
+++ b/tickets/README.md
@@ -1,1 +1,4 @@
 # Tickets application API specification
+
+Swagger UI:
+<https://dal-lab.github.io/openapi-sample/tickets>


### PR DESCRIPTION
GitHub Actions를 이용해 Tickets API의 Swagger UI 문서를 만들고, GitHub Pages로 배포.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- Tickets API 전용 Swagger UI가 추가되어 API 명세를 쉽게 확인할 수 있습니다.
- **문서**
	- Tickets 관련 문서에 Swagger UI 접근 링크가 포함되어, API 문서를 보다 편리하게 이용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->