### PR TITLE
Comment의 `ticket_id` 속성 삭제

### DIFF
--- a/tickets/openapi.yaml
+++ b/tickets/openapi.yaml
@@ -30,7 +30,6 @@ paths:
                     status: open
                     comments:
                       - id: 01JQFRVCZ36PC7C3CDYWGGGVH2
-                        ticket_id: 01JQFRSC1ZD0BD7J7CFC4Y4KXP
                         content: This is the first comment.
                   - id: 01JQA8YHSK6NSD1QEEJPES8592
                     title: Slow load
@@ -226,7 +225,6 @@ paths:
                 properties: {}
               example:
                 - id: 01JQFRVCZ36PC7C3CDYWGGGVH2
-                  ticket_id: 01JQFRSC1ZD0BD7J7CFC4Y4KXP
                   content: This is the first comment.
           headers: {}
       security: []
@@ -267,7 +265,6 @@ paths:
                 properties: {}
               example:
                 id: 01JQX26V9XH60Y98S7Z1J87EYR
-                ticket_id: 01JQFRSC1ZD0BD7J7CFC4Y4KXP
                 content: This is the first comment.
           headers: {}
       security: []
@@ -303,7 +300,6 @@ paths:
                 properties: {}
               example:
                 id: 01JQX26V9XH60Y98S7Z1J87EYR
-                ticket_id: 01JQFRSC1ZD0BD7J7CFC4Y4KXP
                 content: This is the first comment.
           headers: {}
       security: []


### PR DESCRIPTION
Ticket API 스펙 문서에서 Comment에 잘못 들어간 `ticket_id` 속성 삭제.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - Tickets API의 댓글 예제에서 티켓 참조 정보를 제거하여, API 응답 구조가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->